### PR TITLE
GitHubのLanguagesの割合を正常に戻す

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,13 @@
 # See https://git-scm.com/docs/gitattributes for more about git attribute files.
 
 # Mark the database schema as having been generated.
-db/schema.rb linguist-generated
+src/db/schema.rb linguist-generated
 
 # Mark the yarn lockfile as having been generated.
-yarn.lock linguist-generated
+src/yarn.lock linguist-generated
 
 # Mark any vendored files as having been vendored.
-vendor/* linguist-vendored
+src/vendor/* linguist-vendored
+
+# webpackerのコンパイルで作成されるファイルをGitHub上で言語ファイル(.js)として認識させず、diff差異も表示させない
+src/public/packs/* linguist-vendored


### PR DESCRIPTION
[ 何をしたか ]
webpackerでコンパイルした際に作成される、public/packs配下のファイルについてGitHubで言語ファイルとして認識させないようにする＋diff差異も表示させない。

[ なぜ必要だったか ]
public/packs/js ディレクトリに入るファイルはサイズが大きく、言語ファイルとして認識されてしまうとLanguageの割合がほとんどjavascriptになってしまう（作業前は94.2%でした）
public/packs配下にあるもう一つのgit管理しているファイル（manifest.json）もコンパイル時に内容が自動更新されるため、diff差異を確認する可能性はほぼ無いと判断した